### PR TITLE
Use node16 instead of node12 (Fixes #27)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,5 +44,5 @@ outputs:
     description: 'The path to the SARIF file that is generated containing all the results.'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Use node16 instead of node12 as the latter is deprecated. I have not tested the changes.

Fixes #27 