### PR TITLE
Run file analysis asynchronously 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9352,8 +9352,8 @@ async function main() {
 
     // TODO: timeouts
     await Promise.all(
-      analyzeCommands.map(cmd => {
-        return async () => {
+      analyzeCommands.map(cmd => (
+         (async () => {
           core.info(`Running analysis on ${cmd.source}`)
           const execOptions = {
             cwd: buildDir,
@@ -9366,8 +9366,8 @@ async function main() {
             core.info(`Environment: ${execOptions.env}`);
             throw new Error(`Analysis failed due to compile errors in ${cmd.source}`) // No need to continue the analysis once a file has failed
           }
-        }
-      })
+        })()
+      ))
     );
     
     core.info("Combining sarif for all files");

--- a/dist/index.js
+++ b/dist/index.js
@@ -9368,7 +9368,7 @@ async function main() {
 
     // First file is the pch - If there's no pch, it's going to be a regular file
     // It has to be compiled separately, as all other files require it [and a "Permission Denioed" error will be raised if they try to access it] 
-    await processCommand(createAnalysisCommands[0])
+    await processCommand(analyzeCommands[0])
     
     // We have to process in chunks, otherwise we'll run into out-of-memory situations
     // generally [I believe] it makes no sense to run more "parallel" jobs than the number of cpu threads

--- a/dist/index.js
+++ b/dist/index.js
@@ -9352,21 +9352,22 @@ async function main() {
 
     // TODO: timeouts
     await Promise.all(
-      analyzeCommands.map(command => (
-        async () => {
+      analyzeCommands.map(cmd => {
+        return async () => {
+          core.info(`Running analysis on ${cmd.source}`)
           const execOptions = {
             cwd: buildDir,
-            env: command.env,
+            env: cmd.env,
           }
           try {
-            await exec.exec(`"${command.compiler}"`, command.args, execOptions);
+            await exec.exec(`"${cmd.compiler}"`, cmd.args, execOptions);
           } catch (err) {
-            core.info(`Compilation of ${command.source} failed with error: ${err}`);
+            core.info(`Compilation of ${cmd.source} failed with error: ${err}`);
             core.info(`Environment: ${execOptions.env}`);
-            throw new Error(`Analysis failed due to compile errors in ${command.source}`) // No need to continue the analysis once a file has failed
+            throw new Error(`Analysis failed due to compile errors in ${cmd.source}`) // No need to continue the analysis once a file has failed
           }
         }
-      ))
+      })
     );
     
     core.info("Combining sarif for all files");

--- a/dist/index.js
+++ b/dist/index.js
@@ -9363,7 +9363,7 @@ async function main() {
           } catch (err) {
             core.info(`Compilation of ${cmd.source} failed with error: ${err}`);
             core.info(`Environment: ${JSON.stringify(execOptions.env, null, 4)}`);
-            throw new Error(`Analysis failed due to compile errors in ${cmd.source}`)
+            throw new Error(`Analysis failed due to errors in while trying to compile ${cmd.source}`)
           }
         })()
       ))

--- a/dist/index.js
+++ b/dist/index.js
@@ -9348,6 +9348,8 @@ async function main() {
       throw new Error('No C/C++ files were found in the project that could be analyzed.');
     }
 
+    core.info(`Running analysis on ${analyzeCommands.length} files`);
+
     // TODO: timeouts
     await Promise.all(
       analyzeCommands.map(command => (
@@ -9367,7 +9369,10 @@ async function main() {
       ))
     );
     
+    core.info("Combining sarif for all files");
     combineSarif(resultPath, analyzeCommands.map(command => command.sarifLog));
+
+    core.info("Saving SARIF output");
     core.setOutput("sarif", resultPath);
   } catch (error) {
     if (core.isDebug()) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9354,7 +9354,6 @@ async function main() {
     await Promise.all(
       analyzeCommands.map(cmd => (
          (async () => {
-          core.info(`Running analysis on ${cmd.source}`)
           const execOptions = {
             cwd: buildDir,
             env: cmd.env,
@@ -9363,8 +9362,8 @@ async function main() {
             await exec.exec(`"${cmd.compiler}"`, cmd.args, execOptions);
           } catch (err) {
             core.info(`Compilation of ${cmd.source} failed with error: ${err}`);
-            core.info(`Environment: ${execOptions.env}`);
-            throw new Error(`Analysis failed due to compile errors in ${cmd.source}`) // No need to continue the analysis once a file has failed
+            core.info(`Environment: ${JSON.stringify(execOptions.env)}`);
+            throw new Error(`Analysis failed due to compile errors in ${cmd.source}`)
           }
         })()
       ))

--- a/dist/index.js
+++ b/dist/index.js
@@ -9362,7 +9362,7 @@ async function main() {
             await exec.exec(`"${cmd.compiler}"`, cmd.args, execOptions);
           } catch (err) {
             core.info(`Compilation of ${cmd.source} failed with error: ${err}`);
-            core.info(`Environment: ${JSON.stringify(execOptions.env)}`);
+            core.info(`Environment: ${JSON.stringify(execOptions.env, null, 4)}`);
             throw new Error(`Analysis failed due to compile errors in ${cmd.source}`)
           }
         })()

--- a/dist/index.js
+++ b/dist/index.js
@@ -9350,28 +9350,35 @@ async function main() {
 
     core.info(`Running analysis on ${analyzeCommands.length} files`);
 
+    async function processCommand(cmd) {
+      const execOptions = {
+        cwd: buildDir,
+        env: cmd.env,
+      }
+      try {
+        await exec.exec(`"${cmd.compiler}"`, cmd.args, execOptions);
+      } catch (err) {
+        core.info(`Compilation of ${cmd.source} failed with error: ${err}`);
+        core.info(`Environment: ${JSON.stringify(execOptions.env, null, 4)}`);
+        throw new Error(`Analysis failed due to errors in while trying to compile ${cmd.source}`)
+      }
+    }
+
     // TODO: timeouts
+
+    // First file is the pch - If there's no pch, it's going to be a regular file
+    // It has to be compiled separately, as all other files require it [and a "Permission Denioed" error will be raised if they try to access it] 
+    await processCommand(createAnalysisCommands[0])
+    
     // We have to process in chunks, otherwise we'll run into out-of-memory situations
     // generally [I believe] it makes no sense to run more "parallel" jobs than the number of cpu threads
     // TODO: Perhaps use `os.cpus()` to get the cpu thread count?
     const CHUNK_SIZE = 8;
     for (let i = 0; i < analyzeCommands.length; i += CHUNK_SIZE) {
       await Promise.all(
-        analyzeCommands.splice(i, Math.min(i + CHUNK_SIZE, analyzeCommands.length)).map(cmd => (
-           (async () => {
-            const execOptions = {
-              cwd: buildDir,
-              env: cmd.env,
-            }
-            try {
-              await exec.exec(`"${cmd.compiler}"`, cmd.args, execOptions);
-            } catch (err) {
-              core.info(`Compilation of ${cmd.source} failed with error: ${err}`);
-              core.info(`Environment: ${JSON.stringify(execOptions.env, null, 4)}`);
-              throw new Error(`Analysis failed due to errors in while trying to compile ${cmd.source}`)
-            }
-          })()
-        ))
+        analyzeCommands
+          .slice(i, Math.min(i + CHUNK_SIZE, analyzeCommands.length))
+          .map(cmd => processCommand(cmd))
       );
     }
     

--- a/dist/index.js
+++ b/dist/index.js
@@ -9372,7 +9372,7 @@ async function main() {
     core.info("Combining sarif for all files");
     combineSarif(resultPath, analyzeCommands.map(command => command.sarifLog));
 
-    core.info("Saving SARIF output");
+    core.info("Save SARIF output");
     core.setOutput("sarif", resultPath);
   } catch (error) {
     if (core.isDebug()) {

--- a/index.js
+++ b/index.js
@@ -732,31 +732,44 @@ async function main() {
       throw new Error('No C/C++ files were found in the project that could be analyzed.');
     }
 
-    core.info(`Running analysis on ${analyzeCommands.length} files`)
+    core.info(`Running analysis on ${analyzeCommands.length} files`);
+
+    async function processCommand(cmd) {
+      const execOptions = {
+        cwd: buildDir,
+        env: cmd.env,
+      }
+      try {
+        await exec.exec(`"${cmd.compiler}"`, cmd.args, execOptions);
+      } catch (err) {
+        core.info(`Compilation of ${cmd.source} failed with error: ${err}`);
+        core.info(`Environment: ${JSON.stringify(execOptions.env, null, 4)}`);
+        throw new Error(`Analysis failed due to errors in while trying to compile ${cmd.source}`)
+      }
+    }
 
     // TODO: timeouts
-    await Promise.all(
-      analyzeCommands.map(command => (
-        async () => {
-          const execOptions = {
-            cwd: buildDir,
-            env: command.env,
-          }
-          try {
-            await exec.exec(`"${command.compiler}"`, command.args, execOptions);
-          } catch (err) {
-            core.info(`Compilation of ${command.source} failed with error: ${err}`);
-            core.info(`Environment: ${execOptions.env}`);
-            throw new Error(`Analysis failed due to compile errors in ${command.source}`) // No need to continue the analysis once a file has failed
-          }
-        }
-      ))
-    );
+
+    // First file is the pch - If there's no pch, it's going to be a regular file
+    // It has to be compiled separately, as all other files require it [and a "Permission Denioed" error will be raised if they try to access it] 
+    await processCommand(analyzeCommands[0])
     
-    core.info("Combining SARIF for all files")
+    // We have to process in chunks, otherwise we'll run into out-of-memory situations
+    // generally [I believe] it makes no sense to run more "parallel" jobs than the number of cpu threads
+    // TODO: Perhaps use `os.cpus()` to get the cpu thread count?
+    const CHUNK_SIZE = 8;
+    for (let i = 0; i < analyzeCommands.length; i += CHUNK_SIZE) {
+      await Promise.all(
+        analyzeCommands
+          .slice(i, Math.min(i + CHUNK_SIZE, analyzeCommands.length))
+          .map(cmd => processCommand(cmd))
+      );
+    }
+    
+    core.info("Combining sarif for all files");
     combineSarif(resultPath, analyzeCommands.map(command => command.sarifLog));
 
-    core.info("Saving SARIF output");
+    core.info("Save SARIF output");
     core.setOutput("sarif", resultPath);
   } catch (error) {
     if (core.isDebug()) {
@@ -770,6 +783,7 @@ async function main() {
       .forEach(log => fs.unlinkSync(log));
   }
 }
+
 
 if (require.main === module) {
   (async () => {

--- a/index.js
+++ b/index.js
@@ -745,6 +745,7 @@ async function main() {
           } catch (err) {
             core.info(`Compilation of ${command.source} failed with error: ${err}`);
             core.info(`Environment: ${execOptions.env}`);
+            throw new Error(`Analysis failed due to compile errors in ${command.source}`) // No need to continue the analysis once a file has failed
           }
         }
       ))

--- a/index.js
+++ b/index.js
@@ -732,37 +732,32 @@ async function main() {
       throw new Error('No C/C++ files were found in the project that could be analyzed.');
     }
 
-    // TODO: parallelism
-    const failedSourceFiles = [];
-    for (const command of analyzeCommands) {
-      const execOptions = {
-        cwd: buildDir,
-        env: command.env,
-      };
-
-      // TODO: timeouts
-      core.info(`Running analysis on: ${command.source}`);
-      try {
-        await exec.exec(`"${command.compiler}"`, command.args, execOptions);
-      } catch (err) {
-        core.debug(`Compilation failed with error: ${err}`);
-        core.debug("Environment:");
-        core.debug(execOptions.env);
-        failedSourceFiles.push(command.source);
-      }
+    // TODO: timeouts
+    let failed = []
+    await Promise.all(
+      analyzeCommands.map(command => (
+        async () => {
+          const execOptions = {
+            cwd: buildDir,
+            env: command.env,
+          }
+          try {
+            await exec.exec(`"${command.compiler}"`, command.args, execOptions);
+          } catch (err) {
+            core.info(`Compilation of ${command.source} failed with error: ${err}`);
+            core.info(`Environment: ${execOptions.env}`);
+            failed.push(command.source);
+          }
+        }
+      ))
+    );
+    
+    if (failed.length > 0) {
+      throw new Error(`Analysis failed due to compiler errors in files: ${failed.map(file => path.basename(file)).join(",")}`);
     }
 
-    if (failedSourceFiles.length > 0) {
-      const fileList = failedSourceFiles
-        .map(file => path.basename(file))
-        .join(",");
-      throw new Error(`Analysis failed due to compiler errors in files: ${fileList}`);
-    }
-
-    const sarifResults = analyzeCommands.map(command => command.sarifLog);
-    combineSarif(resultPath, sarifResults);
+    combineSarif(resultPath, analyzeCommands.map(command => command.sarifLog));
     core.setOutput("sarif", resultPath);
-
   } catch (error) {
     if (core.isDebug()) {
       core.setFailed(error.stack)

--- a/index.js
+++ b/index.js
@@ -733,7 +733,6 @@ async function main() {
     }
 
     // TODO: timeouts
-    let failed = []
     await Promise.all(
       analyzeCommands.map(command => (
         async () => {
@@ -746,16 +745,11 @@ async function main() {
           } catch (err) {
             core.info(`Compilation of ${command.source} failed with error: ${err}`);
             core.info(`Environment: ${execOptions.env}`);
-            failed.push(command.source);
           }
         }
       ))
     );
     
-    if (failed.length > 0) {
-      throw new Error(`Analysis failed due to compiler errors in files: ${failed.map(file => path.basename(file)).join(",")}`);
-    }
-
     combineSarif(resultPath, analyzeCommands.map(command => command.sarifLog));
     core.setOutput("sarif", resultPath);
   } catch (error) {

--- a/index.js
+++ b/index.js
@@ -732,6 +732,8 @@ async function main() {
       throw new Error('No C/C++ files were found in the project that could be analyzed.');
     }
 
+    core.info(`Running analysis on ${analyzeCommands.length} files`)
+
     // TODO: timeouts
     await Promise.all(
       analyzeCommands.map(command => (
@@ -751,7 +753,10 @@ async function main() {
       ))
     );
     
+    core.info("Combining SARIF for all files")
     combineSarif(resultPath, analyzeCommands.map(command => command.sarifLog));
+
+    core.info("Saving SARIF output");
     core.setOutput("sarif", resultPath);
   } catch (error) {
     if (core.isDebug()) {


### PR DESCRIPTION
Another important change is that now the analysis of all other files is stopped once any file fails, contrary to the current behavior.
I have not tested the code.

TODO: Webpack `index.js` into `dist/index.js` - I have no clue how to do it